### PR TITLE
Corrige acentuação do nível intermediário

### DIFF
--- a/pages/Flashcards.jsx
+++ b/pages/Flashcards.jsx
@@ -61,7 +61,7 @@ export default function FlashcardsPage() {
             onChange={(e) => setNivel(e.target.value)}
           >
             <option value="iniciante">iniciante</option>
-            <option value="intermediario">intermediario</option>
+            <option value="intermediario">intermediário</option>
             <option value="avancado">avancado</option>
           </select>
         </label>

--- a/pages/Simulados.jsx
+++ b/pages/Simulados.jsx
@@ -61,7 +61,7 @@ export default function SimuladosPage() {
             onChange={(e) => setNivel(e.target.value)}
           >
             <option value="iniciante">iniciante</option>
-            <option value="intermediario">intermediario</option>
+            <option value="intermediario">intermediário</option>
             <option value="avancado">avancado</option>
           </select>
         </label>


### PR DESCRIPTION
## Summary
- corrige exibição do texto "intermediário" nas opções de nível dos simulados e flashcards

## Testing
- `npm test` *(erro: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ab78c87050832fab4a6d27e6c8bac5