### PR TITLE
Add safeParseJSON unit tests

### DIFF
--- a/__tests__/safeParseJSON.test.js
+++ b/__tests__/safeParseJSON.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { safeParseJSON } from '../services/safeParseJSON.js';
+
+test('parses valid JSON', () => {
+  const json = '{"foo": 1}';
+  const result = safeParseJSON(json);
+  assert.deepEqual(result, { foo: 1 });
+});
+
+test('throws error with expected message for invalid JSON', () => {
+  const badJson = '{foo: 1';
+  assert.throws(() => safeParseJSON(badJson), { message: 'Resposta inválida do modelo.' });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "react": "18.3.1",

--- a/services/geminiService.js
+++ b/services/geminiService.js
@@ -1,5 +1,6 @@
 // services/geminiService.js
 import { GoogleGenAI } from "@google/genai";
+import { safeParseJSON } from "./safeParseJSON.js";
 
 const API_KEY = process.env.GEMINI_API_KEY || "";
 const MODEL   = "gemini-2.5-flash";
@@ -24,14 +25,6 @@ function readText(res) {
     }
   } catch {}
   return "";
-}
-
-function safeParseJSON(txt) {
-  try { return JSON.parse(txt); }
-  catch (e) {
-    console.error("[Gemini] JSON malformado:", txt);
-    throw new Error("Resposta inválida do modelo.");
-  }
 }
 
 /* =============== PLANO SEMANAL =============== */

--- a/services/safeParseJSON.js
+++ b/services/safeParseJSON.js
@@ -1,0 +1,7 @@
+export function safeParseJSON(txt) {
+  try { return JSON.parse(txt); }
+  catch (e) {
+    console.error("[Gemini] JSON malformado:", txt);
+    throw new Error("Resposta inválida do modelo.");
+  }
+}


### PR DESCRIPTION
## Summary
- extract safeParseJSON to its own module
- add Node test suite validating JSON parsing and error handling
- configure npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab78c9e114832faa5e0dbd8db57767