### PR TITLE
fix: guard localStorage access in store

### DIFF
--- a/store/useStore.js
+++ b/store/useStore.js
@@ -1,6 +1,15 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+const storage =
+    typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage
+        : {
+              getItem: () => null,
+              setItem: () => {},
+              removeItem: () => {},
+          };
+
 export const useStore = create(
     persist(
         (set) => ({
@@ -25,7 +34,7 @@ export const useStore = create(
         }),
         {
             name: 'coach-unb-storage',
-            storage: createJSONStorage(() => localStorage),
+            storage: createJSONStorage(() => storage),
         }
     )
 );


### PR DESCRIPTION
## Summary
- avoid ReferenceError by checking for `window.localStorage` before using it
- provide no-op storage fallback for non-browser environments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab7eee2e50832fa21065a75fdea910