### PR TITLE
Improve JSON parsing from noisy AI responses

### DIFF
--- a/__tests__/safeParseJSON.test.js
+++ b/__tests__/safeParseJSON.test.js
@@ -12,3 +12,9 @@ test('throws error with expected message for invalid JSON', () => {
   const badJson = '{foo: 1';
   assert.throws(() => safeParseJSON(badJson), { message: 'Resposta inválida do modelo.' });
 });
+
+test('parses JSON even when surrounded by extraneous text', () => {
+  const noisyJson = 'resultado:\n```json\n{"foo": 1}\n``` fim';
+  const result = safeParseJSON(noisyJson);
+  assert.deepEqual(result, { foo: 1 });
+});

--- a/services/safeParseJSON.js
+++ b/services/safeParseJSON.js
@@ -1,6 +1,12 @@
 export function safeParseJSON(txt) {
-  try { return JSON.parse(txt); }
-  catch (e) {
+  try {
+    if (typeof txt !== 'string') return txt;
+    const match = txt.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+    if (match) {
+      return JSON.parse(match[0]);
+    }
+    return JSON.parse(txt);
+  } catch (e) {
     console.error("[Gemini] JSON malformado:", txt);
     throw new Error("Resposta inválida do modelo.");
   }


### PR DESCRIPTION
## Summary
- Enhance `safeParseJSON` to extract JSON payloads from strings containing extra text or code fences
- Add regression test ensuring noisy strings are parsed correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab7eee2e50832fa21065a75fdea910