### PR TITLE
feat: auto exam profile with news proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains everything you need to run the Coach UnB app locally or
   - `GEMINI_API_KEY` – Client Key do Google AI Studio
   - `VITE_SUPABASE_URL`
   - `VITE_SUPABASE_ANON_KEY`
+  - `VITE_NEWS_PROXY_URL` – URL do serviço de notícias (ver abaixo)
 
 Configure-as em `.env.local` para desenvolvimento e em _Environment Variables_ no Render para produção.
 
@@ -34,3 +35,11 @@ No [Google AI Studio](https://aistudio.google.com/app/apikey), crie uma Client K
 ## Supabase
 
 Execute o script `supabase.sql` para criar as tabelas de histórico, quizzes e matérias favoritas com as políticas de RLS necessárias.
+
+## News proxy
+
+Há uma micro-API Node em `/api/news-proxy` usada para buscar notícias recentes do exame via Google News RSS.
+
+No Render, crie um novo **Web Service** apontando para essa pasta (`api/news-proxy`) com **Node 20** e defina a env `ALLOW_ORIGIN=https://coach-unb-2026-medicina.onrender.com`.
+
+Use a URL pública do serviço na variável `VITE_NEWS_PROXY_URL` do site principal.

--- a/api/news-proxy/package.json
+++ b/api/news-proxy/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "news-proxy",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2",
+    "rss-to-json": "^2.0.3",
+    "cors": "^2.8.5"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/api/news-proxy/server.js
+++ b/api/news-proxy/server.js
@@ -1,0 +1,31 @@
+import express from "express";
+import cors from "cors";
+import fetch from "node-fetch";
+import { parse } from "rss-to-json";
+
+const app = express();
+app.use(cors({ origin: process.env.ALLOW_ORIGIN || "*" }));
+
+// Ex.: /news?q=vestibular%20unb
+app.get("/news", async (req, res) => {
+  try {
+    const q = (req.query.q || "").toString();
+    if (!q) return res.status(400).json({ error: "missing q" });
+
+    // Google News RSS
+    const url = `https://news.google.com/rss/search?q=${encodeURIComponent(q)}&hl=pt-BR&gl=BR&ceid=BR:pt-419`;
+    const rss = await parse(url);
+    const items = (rss?.items || []).map(i => ({
+      title: i.title,
+      url: i.link,
+      source: i.source?.title || "Google News",
+      publishedAt: i.published
+    }));
+    res.json({ items });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log("news-proxy on " + port));

--- a/services/examProfileService.js
+++ b/services/examProfileService.js
@@ -1,0 +1,28 @@
+import { supabase } from "./supabaseClient.js";
+import { discoverExamProfile } from "./geminiService.js";
+import { addUserSubject } from "./subjectsService.js";
+
+export async function autoPrepareExam({ targetExam = "", university = "", location = "" }) {
+  const profile = await discoverExamProfile({ targetExam, university, location });
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await supabase.from("exam_profiles").upsert({
+        user_id: user.id,
+        target_exam: targetExam,
+        university,
+        location,
+        profile_json: profile,
+      });
+
+      for (const s of profile?.exam_overview?.subjects || []) {
+        try { await addUserSubject(s); } catch {}
+      }
+    }
+  } catch (e) {
+    console.error("[autoPrepareExam] erro:", e);
+  }
+
+  return profile;
+}

--- a/services/newsService.js
+++ b/services/newsService.js
@@ -1,0 +1,34 @@
+const BASE_URL = import.meta.env.VITE_NEWS_PROXY_URL;
+
+export function buildNewsQueries({ targetExam = "", university = "", location = "" } = {}) {
+  const set = new Set();
+  if (targetExam) set.add(targetExam);
+  if (university) {
+    set.add(`${university} vestibular`);
+    set.add(`vestibular ${university}`);
+  }
+  if (targetExam && university) set.add(`${targetExam} ${university}`);
+  if (targetExam && location) set.add(`${targetExam} ${location}`);
+  return Array.from(set);
+}
+
+export async function fetchNews({ queries = [], limit = 10 } = {}) {
+  if (!BASE_URL) throw new Error("NEWS proxy não configurado.");
+  const map = new Map();
+  for (const q of queries) {
+    try {
+      const res = await fetch(`${BASE_URL}/news?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      for (const item of data.items || []) {
+        if (!map.has(item.url)) {
+          map.set(item.url, item);
+        }
+      }
+    } catch (e) {
+      console.error("[fetchNews] erro:", e);
+    }
+  }
+  const arr = Array.from(map.values());
+  arr.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+  return arr.slice(0, limit);
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -64,3 +64,32 @@ create policy "us_insert_own" on public.user_subjects
 for insert with check (auth.uid() = user_id);
 create policy "us_delete_own" on public.user_subjects
 for delete using (auth.uid() = user_id);
+
+-- PERFIL DO EXAME
+create table if not exists public.exam_profiles (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  target_exam text,
+  university text,
+  location text,
+  profile_json jsonb not null,
+  updated_at timestamptz default now(),
+  primary key (user_id, target_exam)
+);
+alter table public.exam_profiles enable row level security;
+
+drop policy if exists exam_profiles_select_own on public.exam_profiles;
+create policy exam_profiles_select_own
+on public.exam_profiles
+for select using (auth.uid() = user_id);
+
+drop policy if exists exam_profiles_upsert_own on public.exam_profiles;
+create policy exam_profiles_upsert_own
+on public.exam_profiles
+for insert with check (auth.uid() = user_id);
+
+drop policy if exists exam_profiles_update_own on public.exam_profiles;
+create policy exam_profiles_update_own
+on public.exam_profiles
+for update using (auth.uid() = user_id);
+
+select pg_notify('pgrst','reload schema');


### PR DESCRIPTION
## Summary
- add Gemini-powered exam profile discovery and integrate subjects into study plans
- persist exam profile and subjects in Supabase and fetch news via proxy service
- enhance Planner with one-click auto-prepare flow and news section

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "@supabase/supabase-js")*


------
https://chatgpt.com/codex/tasks/task_b_68ab9299489c832f8bed41da5deb5912