### PR TITLE
Add history actions for flashcards and quizzes

### DIFF
--- a/components/history/FlashcardsView.jsx
+++ b/components/history/FlashcardsView.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-export default function FlashcardsView({ payload = [] }) {
+export default function FlashcardsView({ payload = [], id }) {
+  const navigate = useNavigate();
   const [show, setShow] = useState({});
   if (!Array.isArray(payload)) return <div>Nenhum card.</div>;
   return (
@@ -17,6 +19,12 @@ export default function FlashcardsView({ payload = [] }) {
           </button>
         </div>
       ))}
+      <button
+        onClick={() => navigate(`/flashcards/${id}`)}
+        className="mt-4 bg-indigo-600 text-white px-4 py-2 rounded"
+      >
+        Estudar flashcards
+      </button>
     </div>
   );
 }

--- a/components/history/QuizView.jsx
+++ b/components/history/QuizView.jsx
@@ -6,7 +6,7 @@ export default function QuizView({ payload, onPlay }) {
     <div className="space-y-3">
       <div>{count} questões</div>
       <button onClick={onPlay} className="bg-indigo-600 text-white px-4 py-2 rounded">
-        Jogar agora
+        Refazer simulado
       </button>
     </div>
   );

--- a/pages/History.jsx
+++ b/pages/History.jsx
@@ -142,7 +142,9 @@ export default function HistoryPage() {
         title={selected?.subject || selected?.payload?.title}
       >
         {selected?.kind === 'plan' && <PlanView payload={selected.payload} />}
-        {selected?.kind === 'flashcards' && <FlashcardsView payload={selected.payload} />}
+        {selected?.kind === 'flashcards' && (
+          <FlashcardsView payload={selected.payload} id={selected.id} />
+        )}
         {selected?.kind === 'quiz' && (
           <QuizView payload={selected.payload} onPlay={() => onPlay(selected)} />
         )}


### PR DESCRIPTION
## Summary
- Add link to study flashcards from history modal
- Rename quiz history CTA to "Refazer simulado"
- Pass history id to flashcards modal view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac87839aac832f87b36df6f29ee0d4