### PR TITLE
Add default preparatory subjects and describe platform resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,20 @@ No Render, crie um **Web Service** apontando para essa pasta com Node 20 e defin
 - `ALLOW_ORIGIN=https://coach-unb-2026-medicina.onrender.com`
 
 No front, use a URL pública desse serviço em `VITE_VIDEO_PROXY_URL`.
+
+## Disciplinas e recursos
+
+A plataforma Coach UnB indica a teoria essencial para cada matéria e oferece baterias de questões padronizadas no modelo Cebraspe. Também há minissimulados por disciplina, testes práticos com respostas comentadas e exercícios de aprofundamento.
+
+Disciplinas abordadas no preparatório:
+
+- História
+- Geografia
+- Sociologia
+- Filosofia
+- Literatura e Interpretação de Texto
+- Gramática
+- Física
+- Química
+- Matemática
+- Biologia

--- a/data/subjects.json
+++ b/data/subjects.json
@@ -1,0 +1,13 @@
+[
+  "História",
+  "Geografia",
+  "Sociologia",
+  "Filosofia",
+  "Literatura",
+  "Interpretação de Texto",
+  "Gramática",
+  "Física",
+  "Química",
+  "Matemática",
+  "Biologia"
+]

--- a/pages/Subjects.jsx
+++ b/pages/Subjects.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { listUserSubjects, addUserSubject, removeUserSubject } from "../services/subjectsService.js";
+import defaultSubjects from "../data/subjects.json";
 
 export default function SubjectsPage() {
   const [subjects, setSubjects] = useState([]);
@@ -45,8 +46,22 @@ export default function SubjectsPage() {
   }
 
   return (
-    <main className="p-6 max-w-lg mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Minhas matérias</h1>
+    <main className="p-6 max-w-lg mx-auto space-y-8">
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Disciplinas do preparatório</h1>
+        <p className="mb-4">
+          Nossa plataforma indica a teoria essencial e oferece questões no modelo Cebraspe,
+          minissimulados por matéria, testes práticos comentados e exercícios de aprofundamento.
+        </p>
+        <ul className="list-disc pl-5">
+          {defaultSubjects.map((s) => (
+            <li key={s}>{s}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-bold mb-4">Minhas matérias</h2>
 
       <form onSubmit={onAdd} className="flex gap-2 mb-4">
         <input
@@ -88,6 +103,7 @@ export default function SubjectsPage() {
           {subjects.length === 0 && <li>Nenhuma matéria salva.</li>}
         </ul>
       )}
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add static list of core preparatory subjects
- Show default disciplines and study resources on Subjects page
- Document covered subjects and offered materials in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac8e60d0e0832f90086a2b19f13964